### PR TITLE
Fix link

### DIFF
--- a/README.org
+++ b/README.org
@@ -111,17 +111,20 @@ clj -Avulcan diff -p <github-org>
 Sometimes, it is useful to "link" local projects that have local
 changes - similar to *lein checkout*. To get the similar behavior do
 
+Link assumes that the project we're linking is one directory above the vulkan
+directory.
+
 #+begin_src sh
-clj -Avulcan link --project <project>
+clj -Avulcan link --project <org/project>
 # or
-clj -Avulcan link -p <project>
+clj -Avulcan link -p <org/project>
 #+end_src
 
 Unlinking is easier too. Make sure you unlink before comitting
 deps.edn to git
 
 #+begin_src sh
-clj -Avulcan unlink -p <project>
+clj -Avulcan unlink -p <org/project>
 #+end_src
 
 ** Packing Dependencies

--- a/src/vulcan/deps.clj
+++ b/src/vulcan/deps.clj
@@ -74,7 +74,7 @@
 
 (defn link [project]
   (let [{:keys [deps] :as orig} (read-deps-file)]
-    (->> (find-local-projects project deps)
+    (->> (find-local-projects nil project deps)
          (link/link)
          u/spy
          (merge deps)

--- a/src/vulcan/deps.clj
+++ b/src/vulcan/deps.clj
@@ -49,6 +49,10 @@
                      deps)]
     (find-org-deps prefix local-deps)))
 
+(defn find-project [project deps]
+  (let [project-sym (symbol project)]
+    (select-keys deps [project-sym])))
+
 (defn ensure-sorted [orig new]
   (->> (into (sorted-map) new)
        (assoc orig :deps)
@@ -74,7 +78,7 @@
 
 (defn link [project]
   (let [{:keys [deps] :as orig} (read-deps-file)]
-    (->> (find-local-projects nil project deps)
+    (->> (find-project project deps)
          (link/link)
          u/spy
          (merge deps)
@@ -82,7 +86,7 @@
 
 (defn unlink [project]
   (let [{:keys [deps] :as orig} (read-deps-file)]
-    (->> (find-local-projects project deps)
+    (->> (find-project project deps)
          (link/unlink)
          u/spy
          (merge deps)

--- a/src/vulcan/main.clj
+++ b/src/vulcan/main.clj
@@ -77,7 +77,7 @@
 
 (defcommand
   ^{:alias "link"
-    :opts  [["-p" "--project PROJECT" "Project name"]]
+    :opts  [["-p" "--project PROJECT" "Namespace qualified project"]]
     :doc   "link local git repos"}
   link-command [{:keys [options]}]
   (let [{:keys [project]} options]
@@ -85,7 +85,7 @@
 
 (defcommand
   ^{:alias "unlink"
-    :opts  [["-p" "--project PROJECT" "Project name"]]
+    :opts  [["-p" "--project PROJECT" "Namespace qualified project"]]
     :doc   "unlink local git repos"}
   unlink-command [{:keys [options]}]
   (let [{:keys [project]} options]


### PR DESCRIPTION
Link previously assumed we would only want to be linking internal
projects, an assumption that might not be suitable for oss use.

Rather than trying to use internal namespaces, we now use a qualified
project name and link it to a folder.

We assume that we link to ../project-dir, it may be useful to
parameterize this