### PR TITLE
Fix reference in self-update

### DIFF
--- a/src/vulcan/deps.clj
+++ b/src/vulcan/deps.clj
@@ -100,7 +100,7 @@
     (-> (read-deps-file global-deps-file)
         (u/rmerge
          {:aliases
-          {:deps
+          {:vulcan
            {:extra-deps {(symbol repo) dep}
             :main-opts  ["-m" "vulcan.deps"]}
            :test


### PR DESCRIPTION
Previously self-update referred to deps, which was our internal alias,
but since we've since settled on vulcan the self-update should be
consistent with that naming.