### PR TITLE
Fix import to make runable in 1.10.0

### DIFF
--- a/src/vulcan/deps/classpath.clj
+++ b/src/vulcan/deps/classpath.clj
@@ -6,7 +6,7 @@
    [me.raynes.fs :as fs]
    [vulcan.util :as u])
   (:import
-   (clojure.lang.RT)))
+   clojure.lang.RT))
 
 (defn find-procurer [dep]
   (cond


### PR DESCRIPTION
Fixes:

```
Clojure 1.10.0
user=> (require 'vulcan.deps.classpath)
Syntax error macroexpanding clojure.core/ns at (classpath.clj:1:1).
() - failed: Insufficient input at: [:ns-clauses :import :classes :package-list :classes] spec: :clojure.core.specs.alpha/package-list
(clojure.lang.RT) - failed: simple-symbol? at: [:ns-clauses :import :classes :class] spec: :clojure.core.specs.alpha/import-list
:import - failed: #{:refer-clojure} at: [:ns-clauses :refer-clojure :clause] spec: :clojure.core.specs.alpha/ns-refer-clojure
:import - failed: #{:require} at: [:ns-clauses :require :clause] spec: :clojure.core.specs.alpha/ns-require
:import - failed: #{:use} at: [:ns-clauses :use :clause] spec: :clojure.core.specs.alpha/ns-use
:import - failed: #{:refer} at: [:ns-clauses :refer :clause] spec: :clojure.core.specs.alpha/ns-refer
:import - failed: #{:load} at: [:ns-clauses :load :clause] spec: :clojure.core.specs.alpha/ns-load
:import - failed: #{:gen-class} at: [:ns-clauses :gen-class :clause] spec: :clojure.core.specs.alpha/ns-gen-class
```